### PR TITLE
power: qpnp-charger: Set the AICL target voltage to 4.352V

### DIFF
--- a/drivers/power/qpnp-charger.c
+++ b/drivers/power/qpnp-charger.c
@@ -6704,7 +6704,7 @@ static int set_prop_batt_health(struct qpnp_chg_chip *chip, int batt_health)
 #define MAX_COUNT	50
 #ifdef CONFIG_MACH_MSM8974_14001
 /* jingchun.wang@Onlinerd.Driver, 2014/01/02  Add for set soft aicl voltage to 4.4v */
-#define SOFT_AICL_VOL	4500
+#define SOFT_AICL_VOL	4352
 #endif /*CONFIG_MACH_OPPO*/
 /* jingchun.wang@Onlinerd.Driver, 2013/12/27  Add for auto adapt current by software. */
 static int soft_aicl(struct qpnp_chg_chip *chip)


### PR DESCRIPTION
At full charge, our battery reaches 4.35V, so we only need an intake voltage
that is higher than that. Forcing the intake voltage to be 4.5V+ causes low
current intake for some users, as well as many chargers.

Require an intake voltage of only 4.352V in order to fix the low amperage/charging
speed experienced by users.
